### PR TITLE
use original gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,6 @@ gemspec
 
 gem 'rake', '~> 12.0'
 gem 'rspec', '~> 3.0'
-# tempprary till my PR gets approved in original gem
-gem 'json_api_client', git: 'https://github.com/inderps/json_api_client'
 
 group :development do
   gem 'faker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cirro-ruby-client (1.2.0)
+    cirro-ruby-client (1.2.1)
       faraday_middleware
       json_api_client
       jwt

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,9 @@
-GIT
-  remote: https://github.com/inderps/json_api_client
-  revision: 675e1c8b1bf9978ca4722c2aa19314fb0aa5860b
-  specs:
-    json_api_client (1.17.1)
-      activemodel (>= 3.2.0)
-      activesupport (>= 3.2.0)
-      addressable (~> 2.2)
-      faraday (>= 0.15.2, < 1.2.0)
-      faraday_middleware (>= 0.9.0, < 1.2.0)
-      rack (>= 0.2)
-
 PATH
   remote: .
   specs:
-    cirro-ruby-client (1.1.0)
+    cirro-ruby-client (1.2.0)
       faraday_middleware
+      json_api_client
       jwt
 
 GEM
@@ -37,13 +26,21 @@ GEM
     diff-lcs (1.4.4)
     faker (2.14.0)
       i18n (>= 1.6, < 2)
-    faraday (1.0.1)
+    faraday (1.1.0)
       multipart-post (>= 1.2, < 3)
+      ruby2_keywords
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
     hashdiff (1.0.1)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
+    json_api_client (1.17.1)
+      activemodel (>= 3.2.0)
+      activesupport (>= 3.2.0)
+      addressable (~> 2.2)
+      faraday (>= 0.15.2, < 1.2.0)
+      faraday_middleware (>= 0.9.0, < 1.2.0)
+      rack (>= 0.2)
     jwt (2.2.2)
     method_source (1.0.0)
     minitest (5.14.2)
@@ -87,6 +84,7 @@ GEM
     rubocop-rspec (1.43.2)
       rubocop (~> 0.87)
     ruby-progressbar (1.10.1)
+    ruby2_keywords (0.0.2)
     thread_safe (0.3.6)
     tzinfo (1.2.8)
       thread_safe (~> 0.1)
@@ -103,7 +101,6 @@ PLATFORMS
 DEPENDENCIES
   cirro-ruby-client!
   faker
-  json_api_client!
   pry
   rake (~> 12.0)
   rspec (~> 3.0)

--- a/cirro-ruby-client.gemspec
+++ b/cirro-ruby-client.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'jwt'
   spec.add_runtime_dependency 'faraday_middleware'
+  spec.add_runtime_dependency 'json_api_client'
 end

--- a/lib/cirro_io/base_association.rb
+++ b/lib/cirro_io/base_association.rb
@@ -1,0 +1,33 @@
+module JsonApiClient
+  module Associations
+    class BaseAssociation
+      attr_reader :attr_name, :klass, :options
+      def initialize(attr_name, klass, options = {})
+        @attr_name = attr_name
+        @klass = klass
+        @options = options
+      end
+
+      def association_class
+        @association_class ||= Utils.compute_type(klass, options.fetch(:class_name) do
+          attr_name.to_s.classify
+        end)
+      end
+
+      def data(url)
+        from_result_set(association_class.requestor.linked(url))
+      end
+
+      def from_result_set(result_set)
+        result_set.to_a
+      end
+
+      def load_records(data)
+        data.map do |d|
+          record_class = Utils.compute_type(klass, klass.key_formatter.unformat(d['type']).classify)
+          record_class.load id: d['id']
+        end
+      end
+    end
+  end
+end

--- a/lib/cirro_io/client.rb
+++ b/lib/cirro_io/client.rb
@@ -1,4 +1,10 @@
 require 'json_api_client'
+
+# temporary monkey patch code to fix gem bug
+require 'cirro_io/has_one'
+require 'cirro_io/base_association'
+# temporary monkey patch code to fix gem bug
+
 require 'cirro_io/client/version'
 require 'cirro_io/client/configuration'
 require 'cirro_io/client/response_debugging_middleware'

--- a/lib/cirro_io/client/version.rb
+++ b/lib/cirro_io/client/version.rb
@@ -1,7 +1,7 @@
 # rubocop:disable Style/MutableConstant
 module CirroIO
   module Client
-    VERSION = '1.2.0'
+    VERSION = '1.2.1'
   end
 end
 # rubocop:enable Style/MutableConstant

--- a/lib/cirro_io/has_one.rb
+++ b/lib/cirro_io/has_one.rb
@@ -1,0 +1,16 @@
+module JsonApiClient
+  module Associations
+    module HasOne
+      class Association < BaseAssociation
+        def from_result_set(result_set)
+          result_set.first
+        end
+
+        def load_records(data)
+          record_class = Utils.compute_type(klass, klass.key_formatter.unformat(data['type']).classify)
+          record_class.load id: data['id']
+        end
+      end
+    end
+  end
+end

--- a/spec/cirro_io/client/base_spec.rb
+++ b/spec/cirro_io/client/base_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CirroIO::Client::Base do
                 'Accept' => 'application/vnd.api+json',
                 'Accept-Encoding' => 'gzip,deflate',
                 'Content-Type' => 'application/vnd.api+json',
-                'User-Agent' => 'Faraday v1.0.1',
+                'User-Agent' => 'Faraday v1.1.0',
                 'Authorization' => 'Bearer jwt-token',
               })
         .to_return(body: File.read('./spec/fixtures/app_worker.json'), headers: { 'Content-Type' => 'application/json' })
@@ -30,7 +30,7 @@ RSpec.describe CirroIO::Client::Base do
                 'Accept' => '*/*',
                 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
                 'Content-Type' => 'application/json',
-                'User-Agent' => 'Faraday v1.0.1',
+                'User-Agent' => 'Faraday v1.1.0',
                 'Authorization' => 'Bearer jwt-token',
               })
         .to_return(status: 201, body: '{}', headers: {})


### PR DESCRIPTION
There is a bug in the original gem. I have already sent the fix https://github.com/JsonApiClient/json_api_client/pull/372. The maintainer told me it will be merged by tomorrow

I was using my forked copy in meantime but it looks like gem does not allow adding dependency directly from a github repo. So we have to live with the original gem with the bug

Once my PR gets merged, I will update the original gem here