### PR TITLE
WIP Require higher json api client version

### DIFF
--- a/cirro-ruby-client.gemspec
+++ b/cirro-ruby-client.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'jwt'
+  spec.add_runtime_dependency 'faraday', '< 1.2.0'
   spec.add_runtime_dependency 'faraday_middleware'
   spec.add_runtime_dependency 'json_api_client', '>= 1.10.0'
 end

--- a/cirro-ruby-client.gemspec
+++ b/cirro-ruby-client.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'jwt'
   spec.add_runtime_dependency 'faraday_middleware'
-  spec.add_runtime_dependency 'json_api_client'
+  spec.add_runtime_dependency 'json_api_client', '>= 1.10.0'
 end

--- a/lib/cirro_io/client/version.rb
+++ b/lib/cirro_io/client/version.rb
@@ -1,7 +1,7 @@
 # rubocop:disable Style/MutableConstant
 module CirroIO
   module Client
-    VERSION = '1.2.2'
+    VERSION = '1.2.3'
   end
 end
 # rubocop:enable Style/MutableConstant


### PR DESCRIPTION
Do we need to bump the version after specifying this in the gemspec?
I couldn't start the example app because of  "undefined method `route_format=' for CirroIO::Client::Base:Class (NoMethodError)" And turns out it is the version of json_api_client which is not working with the newer version of the gem.

Not so sure what the problem here is though. I've ran "bundle update cirro-ruby-client" and this is the result of it in Gemfile.lock
<img width="383" alt="Bildschirmfoto 2021-01-14 um 14 42 41" src="https://user-images.githubusercontent.com/777729/104598440-e1d69c00-5676-11eb-994b-791385e9f8c4.png">
It downgraded json_api_client to 0.9.6, and my guess is json_api_client specifies "faraday (>= 0.15.2, < 1.2.0)" and the update updates it to "faraday (1.3.0)" 🤔 