### PR TITLE
#22 restricts json_api_client version to <= 1.18.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     cirro-ruby-client (1.6.1)
       faraday (< 1.2.0)
       faraday_middleware
-      json_api_client (>= 1.10.0)
+      json_api_client (>= 1.10.0, <= 1.18.0)
       jwt
 
 GEM

--- a/cirro-ruby-client.gemspec
+++ b/cirro-ruby-client.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'jwt'
   spec.add_runtime_dependency 'faraday', '< 1.2.0'
   spec.add_runtime_dependency 'faraday_middleware'
-  spec.add_runtime_dependency 'json_api_client', '>= 1.10.0', '<= 1.18.0'
+  spec.add_runtime_dependency 'json_api_client', '>= 1.10.0', '<= 1.18.0' # TODO: see https://github.com/test-IO/cirro-ruby-client/issues/19
 end

--- a/cirro-ruby-client.gemspec
+++ b/cirro-ruby-client.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'jwt'
   spec.add_runtime_dependency 'faraday', '< 1.2.0'
   spec.add_runtime_dependency 'faraday_middleware'
-  spec.add_runtime_dependency 'json_api_client', '>= 1.10.0'
+  spec.add_runtime_dependency 'json_api_client', '>= 1.10.0', '<= 1.18.0'
 end


### PR DESCRIPTION
see #22 