### PR TITLE
☠️  [hotfix] Setting response attributes when nil value faced

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cirro-ruby-client (2.3.1)
+    cirro-ruby-client (2.3.2)
       activesupport
       faraday (< 1.2.0)
       faraday_middleware

--- a/lib/cirro_io/client/version.rb
+++ b/lib/cirro_io/client/version.rb
@@ -1,7 +1,7 @@
 # rubocop:disable Style/MutableConstant
 module CirroIO
   module Client
-    VERSION = '2.3.1'
+    VERSION = '2.3.2'
   end
 end
 # rubocop:enable Style/MutableConstant

--- a/lib/cirro_io_v2/responses/base.rb
+++ b/lib/cirro_io_v2/responses/base.rb
@@ -15,7 +15,8 @@ module CirroIOV2
           )
           super(*body.slice(*members).keys.map { |attr| values_hash[attr] })
         else
-          super(*body.slice(*members).values)
+          super
+          members.each { |attr| public_send("#{attr}=", body[attr]) }
         end
       end
 

--- a/spec/cirro_io_v2/resources/user_spec.rb
+++ b/spec/cirro_io_v2/resources/user_spec.rb
@@ -34,6 +34,17 @@ RSpec.describe CirroIOV2::Resources::User do
       expect(user.first_name).to eq('Grazyna')
       expect(user.epam[:id]).to eq('12345')
     end
+
+    it 'correctly sets attributes when any attribute is nil' do
+      fixture_body = JSON.parse(File.read('./spec/fixtures/user/find.json'))
+      fixture_body['epam'] = nil
+      stub_request(:get, "#{site}/v2/users/#{user_id}").to_return(body: fixture_body.to_json)
+
+      user = described_class.new(client).find(user_id)
+
+      expect(user.epam).to be_nil
+      expect(user.worker[:billable]).to eq(false)
+    end
   end
 
   describe '#notification_preferences' do


### PR DESCRIPTION
### Why:

For some reason, when the response contains any `nil` field, it skips it, and as a result, we have attributes having wrong values

### Example:
`epam` field is nil, but as a result `worker` (next to epam) value is set to epam field

<img width="1332" alt="image (1)" src="https://user-images.githubusercontent.com/62108816/203768637-ff4b55c7-de4d-4480-b9c9-c8bbb1fa6148.png">

### Suggestions

If you have a better idea of how to fix this - I'm open to any suggestions as this fix is just the first one that came to my mind