### PR TITLE
EPMCIR-1326 Provide staging only endpoint allowing spaces to seed users

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cirro-ruby-client (2.3.2)
+    cirro-ruby-client (2.4.0)
       activesupport
       faraday (< 1.2.0)
       faraday_middleware

--- a/README.md
+++ b/README.md
@@ -127,6 +127,28 @@ client.User.update_notification_preference({
 })
 ```
 
+### Seed user (staging/dev only)
+
+```ruby
+# With params (all of them optional)
+# Password must include at least: 2 letters, 2 digits, 2 special characters
+# Email must be unique
+client.User.create(
+  first_name: 'Human',
+  last_name: 'Being',
+  email: 'iamhuman@test.io',
+  time_zone: 'Berlin',
+  country_code: 'DE',
+  birthday: '1975-11-22',
+  password: '@123456abc@'
+)
+# => User object
+
+# Without params (nimbus-style, all params are seeded by Cirro)
+client.User.create
+# => User object
+```
+
 ## Gig
 ### Create a gig
 

--- a/lib/cirro_io/client/version.rb
+++ b/lib/cirro_io/client/version.rb
@@ -1,7 +1,7 @@
 # rubocop:disable Style/MutableConstant
 module CirroIO
   module Client
-    VERSION = '2.3.2'
+    VERSION = '2.4.0'
   end
 end
 # rubocop:enable Style/MutableConstant

--- a/lib/cirro_io_v2/resources/user.rb
+++ b/lib/cirro_io_v2/resources/user.rb
@@ -1,6 +1,11 @@
 module CirroIOV2
   module Resources
     class User < Base
+      def create(params = nil)
+        response = client.request_client.request(:post, resource_root, body: params)
+        CirroIOV2::Responses::UserResponse.new(response.body)
+      end
+
       def find(id)
         response = client.request_client.request(:get, "#{resource_root}/#{id}")
         CirroIOV2::Responses::UserResponse.new(response.body)

--- a/spec/cirro_io_v2/resources/user_spec.rb
+++ b/spec/cirro_io_v2/resources/user_spec.rb
@@ -20,6 +20,47 @@ RSpec.describe CirroIOV2::Resources::User do
     }
   end
 
+  describe '#create' do
+    let(:params) do
+      {
+        "first_name": 'Maynard',
+        "last_name": 'Keenan',
+        "email": 'mjk@test.io',
+        "time_zone": 'Berlin',
+        "birthday": '1975-11-22',
+        "country_code": 'DE',
+        "password": '@123456abc@',
+      }
+    end
+
+    it 'creates user with params' do
+      stub_api = stub_request(:post, "#{site}/v2/users")
+                 .to_return(body: File.read('./spec/fixtures/user/create.json'))
+
+      user = described_class.new(client).create(params)
+
+      expect(stub_api).to have_been_made
+      expect(user.class).to eq(CirroIOV2::Responses::UserResponse)
+      expect(user.object).to eq('user')
+      expect(user.first_name).to eq(params[:first_name])
+      expect(user.last_name).to eq(params[:last_name])
+      expect(user.time_zone).to eq(params[:time_zone])
+      expect(user.country_code).to eq(params[:country_code])
+      expect(user.birthday).to eq(params[:birthday])
+    end
+
+    it 'creates user without params' do
+      stub_api = stub_request(:post, "#{site}/v2/users")
+                 .to_return(body: File.read('./spec/fixtures/user/create.json'))
+
+      user = described_class.new(client).create
+
+      expect(stub_api).to have_been_made
+      expect(user.class).to eq(CirroIOV2::Responses::UserResponse)
+      expect(user.object).to eq('user')
+    end
+  end
+
   describe '#find' do
     it 'finds user' do
       stub_api = stub_request(:get, "#{site}/v2/users/#{user_id}")

--- a/spec/fixtures/user/create.json
+++ b/spec/fixtures/user/create.json
@@ -1,0 +1,13 @@
+{
+  "id": "1",
+  "object": "user",
+  "first_name": "Maynard",
+  "last_name": "Keenan",
+  "email": "mjk@test.io",
+  "time_zone": "Berlin",
+  "birthday": "1975-11-22",
+  "country_code": "DE",
+  "password": "@123456abc@",
+  "epam": null,
+  "worker": null
+}


### PR DESCRIPTION
https://jira.epam.com/jira/browse/EPMCIR-1326

**Why**:
Spaces like testIO app needs to be able to seed users when the staging/dev env is setup.
Cirro needs to provide an endpoint which is only accessible in staging/dev environment POST /users which allows spaces to create user + app_user with email, password, firstname, lastname etc.

**What**:
* Provide wrapper functionality in cirro-ruby-client gem
* Cover with some tests