### PR TITLE
Use keyword_init for all the structs to prevent messed up attributes for responses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -128,6 +128,9 @@ RSpec/EmptyExampleGroup:
 RSpec/MultipleExpectations:
   Enabled: false
 
+RSpec/MultipleMemoizedHelpers:
+  Max: 12
+
 Style/SymbolArray:
   EnforcedStyle: brackets
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cirro-ruby-client (2.5.12)
+    cirro-ruby-client (2.5.13)
       activesupport
       faraday (< 1.2.0)
       faraday_middleware

--- a/lib/cirro_io/client/version.rb
+++ b/lib/cirro_io/client/version.rb
@@ -1,7 +1,7 @@
 # rubocop:disable Style/MutableConstant
 module CirroIO
   module Client
-    VERSION = '2.5.12'
+    VERSION = '2.5.13'
   end
 end
 # rubocop:enable Style/MutableConstant

--- a/lib/cirro_io_v2/responses/responses.rb
+++ b/lib/cirro_io_v2/responses/responses.rb
@@ -23,16 +23,16 @@ module CirroIOV2
       :NotificationTopicDeleteResponse,
     ].freeze
 
-    UserResponse = Struct.new(:id, :object, :first_name, :last_name, :time_zone, :birthday, :country_code, :epam, :worker, :anonymous_email) do
+    UserResponse = Struct.new(:id, :object, :first_name, :last_name, :time_zone, :birthday, :country_code, :epam, :worker, :anonymous_email, keyword_init: true) do
       include Base
     end
 
-    UserNotificationPreferenceResponse = Struct.new(:id, :object, :locale, :topics) do
+    UserNotificationPreferenceResponse = Struct.new(:id, :object, :locale, :topics, keyword_init: true) do
       self::NESTED_RESPONSES = { topics: :NotificationTopicPreferenceListResponse }.freeze
       include Base
     end
 
-    SpaceInvitationResponse = Struct.new(:id, :object, :token, :subject, :email, :name, :inviter_name, :skip_background_check, :expires_at) do
+    SpaceInvitationResponse = Struct.new(:id, :object, :token, :subject, :email, :name, :inviter_name, :skip_background_check, :expires_at, keyword_init: true ) do
       include Base
     end
 
@@ -51,20 +51,21 @@ module CirroIOV2
                              :filter_query,
                              :tasks,
                              :notification_payload,
-                             :epam_options) do
+                             :epam_options,
+                             keyword_init: true) do
       self::NESTED_RESPONSES = { tasks: :GigTaskListResponse }.freeze
       include Base
     end
 
-    GigTaskResponse = Struct.new(:id, :object, :title, :base_price) do
+    GigTaskResponse = Struct.new(:id, :object, :title, :base_price, keyword_init: true) do
       include Base
     end
 
-    GigInvitationResponse = Struct.new(:id, :object, :status, :gig_id, :user_id, :no_reward, :epam_bench_status) do
+    GigInvitationResponse = Struct.new(:id, :object, :status, :gig_id, :user_id, :no_reward, :epam_bench_status, keyword_init: true) do
       include Base
     end
 
-    GigTimeActivityResponse = Struct.new(:id, :object, :gig_id, :user_id, :description, :duration_in_ms, :date) do
+    GigTimeActivityResponse = Struct.new(:id, :object, :gig_id, :user_id, :description, :duration_in_ms, :date, keyword_init: true) do
       include Base
     end
 
@@ -78,7 +79,8 @@ module CirroIOV2
                                    :multiplier,
                                    :delivery_date,
                                    :cost_center_key,
-                                   :cost_center_data) do
+                                   :cost_center_data,
+                                   keyword_init: true) do
       include Base
     end
 
@@ -92,46 +94,47 @@ module CirroIOV2
                                 :reference_type,
                                 :user_id,
                                 :cost_center_key,
-                                :cost_center_data) do
+                                :cost_center_data,
+                                keyword_init: true) do
       include Base
     end
 
-    NotificationTopicPreferenceResponse = Struct.new(:id, :object, :preferences, :notification_topic_id, :user_id) do
+    NotificationTopicPreferenceResponse = Struct.new(:id, :object, :preferences, :notification_topic_id, :user_id, keyword_init: true) do
       include Base
     end
 
-    NotificationLocaleResponse = Struct.new(:id, :object, :locale, :default, :configurations) do
+    NotificationLocaleResponse = Struct.new(:id, :object, :locale, :default, :configurations, keyword_init: true) do
       self::NESTED_RESPONSES = { configurations: :NotificationConfigurationListResponse }.freeze
       include Base
     end
 
-    NotificationConfigurationResponse = Struct.new(:id, :object, :deliver_by, :format, :kind, :locale) do
+    NotificationConfigurationResponse = Struct.new(:id, :object, :deliver_by, :format, :kind, :locale, keyword_init: true) do
       include Base
     end
 
-    NotificationLayoutResponse = Struct.new(:id, :object, :name, :templates) do
+    NotificationLayoutResponse = Struct.new(:id, :object, :name, :templates, keyword_init: true) do
       self::NESTED_RESPONSES = { templates: :NotificationLayoutTemplateListResponse }.freeze
       include Base
     end
 
-    NotificationLayoutTemplateResponse = Struct.new(:id, :notification_configuration_id, :notification_layout_id, :body) do
+    NotificationLayoutTemplateResponse = Struct.new(:id, :object, :notification_configuration_id, :notification_layout_id, :body, keyword_init: true) do
       include Base
     end
 
-    NotificationTopicResponse = Struct.new(:id, :object, :name, :notification_layout_id, :preferences, :templates) do
+    NotificationTopicResponse = Struct.new(:id, :object, :name, :notification_layout_id, :preferences, :templates, keyword_init: true) do
       self::NESTED_RESPONSES = { templates: :NotificationTemplateListResponse }.freeze
       include Base
     end
 
-    NotificationTemplateResponse = Struct.new(:id, :object, :notification_configuration_id, :notification_topic_id, :subject, :body) do
+    NotificationTemplateResponse = Struct.new(:id, :object, :notification_configuration_id, :notification_topic_id, :subject, :body, keyword_init: true) do
       include Base
     end
 
-    NotificationBroadcastResponse = Struct.new(:id, :object, :payload, :recipients, :notification_topic_id) do
+    NotificationBroadcastResponse = Struct.new(:id, :object, :payload, :recipients, :notification_topic_id, keyword_init: true) do
       include Base
     end
 
-    EpamHeroesBadgeResponse = Struct.new(:content, :refs, :paging, :hasMoreResults) do
+    EpamHeroesBadgeResponse = Struct.new(:content, :refs, :paging, :hasMoreResults, keyword_init: true) do
       include Base
     end
 
@@ -140,8 +143,8 @@ module CirroIOV2
       return const_get(name) if const_defined? name
 
       struct = nil
-      struct = Struct.new(:object, :url, :has_more, :data) if LIST_RESPONSES.include?(name)
-      struct = Struct.new(:id, :object, :deleted) if DELETE_RESPONSES.include?(name)
+      struct = Struct.new(:object, :url, :has_more, :data, keyword_init: true) if LIST_RESPONSES.include?(name)
+      struct = Struct.new(:id, :object, :deleted, keyword_init: true) if DELETE_RESPONSES.include?(name)
 
       return unless struct.present?
 

--- a/lib/cirro_io_v2/responses/responses.rb
+++ b/lib/cirro_io_v2/responses/responses.rb
@@ -23,7 +23,17 @@ module CirroIOV2
       :NotificationTopicDeleteResponse,
     ].freeze
 
-    UserResponse = Struct.new(:id, :object, :first_name, :last_name, :time_zone, :birthday, :country_code, :epam, :worker, :anonymous_email, keyword_init: true) do
+    UserResponse = Struct.new(:id,
+                              :object,
+                              :first_name,
+                              :last_name,
+                              :time_zone,
+                              :birthday,
+                              :country_code,
+                              :epam,
+                              :worker,
+                              :anonymous_email,
+                              keyword_init: true) do
       include Base
     end
 
@@ -32,7 +42,16 @@ module CirroIOV2
       include Base
     end
 
-    SpaceInvitationResponse = Struct.new(:id, :object, :token, :subject, :email, :name, :inviter_name, :skip_background_check, :expires_at, keyword_init: true) do
+    SpaceInvitationResponse = Struct.new(:id,
+                                         :object,
+                                         :token,
+                                         :subject,
+                                         :email,
+                                         :name,
+                                         :inviter_name,
+                                         :skip_background_check,
+                                         :expires_at,
+                                         keyword_init: true) do
       include Base
     end
 

--- a/lib/cirro_io_v2/responses/responses.rb
+++ b/lib/cirro_io_v2/responses/responses.rb
@@ -32,7 +32,7 @@ module CirroIOV2
       include Base
     end
 
-    SpaceInvitationResponse = Struct.new(:id, :object, :token, :subject, :email, :name, :inviter_name, :skip_background_check, :expires_at, keyword_init: true ) do
+    SpaceInvitationResponse = Struct.new(:id, :object, :token, :subject, :email, :name, :inviter_name, :skip_background_check, :expires_at, keyword_init: true) do
       include Base
     end
 

--- a/spec/cirro_io/client/gig_spec.rb
+++ b/spec/cirro_io/client/gig_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe CirroIO::Client::Gig do
     end
   end
 
-  # rubocop:disable RSpec/MultipleMemoizedHelpers
   describe 'bulk_archive_with' do
     before do
       configure_api_client
@@ -83,5 +82,4 @@ RSpec.describe CirroIO::Client::Gig do
       expect(archived_gig.gig_time_activities.map(&:id)).to eq(['1', '2'])
     end
   end
-  # rubocop:enable RSpec/MultipleMemoizedHelpers
 end

--- a/spec/cirro_io_v2/resources/gig_invitation_spec.rb
+++ b/spec/cirro_io_v2/resources/gig_invitation_spec.rb
@@ -57,21 +57,21 @@ RSpec.describe CirroIOV2::Resources::GigInvitation do
     end
 
     context 'when testing response' do
+      subject { described_class.new(client).accept(id, no_reward: true) }
+
       let(:fixture_body) { JSON.parse(File.read('./spec/fixtures/gig_invitation/accept.json')) }
       let(:request_url) { "#{site}/v2/gig_invitations/#{id}/accept" }
       let(:request_action) { :post }
       let(:keys) { fixture_body.keys }
       let(:replace_keys) do
         {
-          'status' => 'aasm_state'
+          'status' => 'aasm_state',
         }
       end
       let(:expected_response_class) { CirroIOV2::Responses::GigInvitationResponse }
       let(:expected_response) do
         fixture_body.excluding(*replace_keys.values)
       end
-
-      subject { described_class.new(client).accept(id, no_reward: true) }
 
       include_examples 'responses'
     end

--- a/spec/cirro_io_v2/resources/gig_invitation_spec.rb
+++ b/spec/cirro_io_v2/resources/gig_invitation_spec.rb
@@ -55,6 +55,26 @@ RSpec.describe CirroIOV2::Resources::GigInvitation do
 
       expect(stub_api).to have_been_made
     end
+
+    context 'when testing response' do
+      let(:fixture_body) { JSON.parse(File.read('./spec/fixtures/gig_invitation/accept.json')) }
+      let(:request_url) { "#{site}/v2/gig_invitations/#{id}/accept" }
+      let(:request_action) { :post }
+      let(:keys) { fixture_body.keys }
+      let(:replace_keys) do
+        {
+          'status' => 'aasm_state'
+        }
+      end
+      let(:expected_response_class) { CirroIOV2::Responses::GigInvitationResponse }
+      let(:expected_response) do
+        fixture_body.excluding(*replace_keys.values)
+      end
+
+      subject { described_class.new(client).accept(id, no_reward: true) }
+
+      include_examples 'responses'
+    end
   end
 
   describe '#reject' do

--- a/spec/cirro_io_v2/resources/gig_result_spec.rb
+++ b/spec/cirro_io_v2/resources/gig_result_spec.rb
@@ -44,6 +44,26 @@ RSpec.describe CirroIOV2::Resources::GigResult do
       expect(gig_result.cost_center_data).to eq(params[:cost_center_data])
       expect(gig_result.cost_center_key).to be_nil
     end
+
+    context 'when testing response' do
+      let(:fixture_body) { JSON.parse(File.read('./spec/fixtures/gig_result/create.json')) }
+      let(:request_url) { "#{site}/v2/gig_results" }
+      let(:request_action) { :post }
+      let(:keys) { fixture_body.keys }
+      let(:replace_keys) do
+        {
+          'delivery_date' => 'billing_date'
+        }
+      end
+      let(:expected_response_class) { CirroIOV2::Responses::GigResultResponse }
+      let(:expected_response) do
+        fixture_body.excluding(*replace_keys.values)
+      end
+
+      subject { described_class.new(client).create(params) }
+
+      include_examples 'responses'
+    end
   end
 
   describe '#list' do

--- a/spec/cirro_io_v2/resources/gig_result_spec.rb
+++ b/spec/cirro_io_v2/resources/gig_result_spec.rb
@@ -46,21 +46,21 @@ RSpec.describe CirroIOV2::Resources::GigResult do
     end
 
     context 'when testing response' do
+      subject { described_class.new(client).create(params) }
+
       let(:fixture_body) { JSON.parse(File.read('./spec/fixtures/gig_result/create.json')) }
       let(:request_url) { "#{site}/v2/gig_results" }
       let(:request_action) { :post }
       let(:keys) { fixture_body.keys }
       let(:replace_keys) do
         {
-          'delivery_date' => 'billing_date'
+          'delivery_date' => 'billing_date',
         }
       end
       let(:expected_response_class) { CirroIOV2::Responses::GigResultResponse }
       let(:expected_response) do
         fixture_body.excluding(*replace_keys.values)
       end
-
-      subject { described_class.new(client).create(params) }
 
       include_examples 'responses'
     end

--- a/spec/cirro_io_v2/resources/gig_time_activity_spec.rb
+++ b/spec/cirro_io_v2/resources/gig_time_activity_spec.rb
@@ -34,21 +34,21 @@ RSpec.describe CirroIOV2::Resources::GigTimeActivity do
     end
 
     context 'when testing response' do
+      subject { described_class.new(client).create(params) }
+
       let(:fixture_body) { JSON.parse(File.read('./spec/fixtures/gig_time_activity/create.json')) }
       let(:request_url) { "#{site}/v2/gig_time_activities" }
       let(:request_action) { :post }
       let(:keys) { fixture_body.keys }
       let(:replace_keys) do
         {
-          'date' => 'delivery_date'
+          'date' => 'delivery_date',
         }
       end
       let(:expected_response_class) { CirroIOV2::Responses::GigTimeActivityResponse }
       let(:expected_response) do
         fixture_body.excluding(*replace_keys.values)
       end
-
-      subject { described_class.new(client).create(params) }
 
       include_examples 'responses'
     end

--- a/spec/cirro_io_v2/resources/gig_time_activity_spec.rb
+++ b/spec/cirro_io_v2/resources/gig_time_activity_spec.rb
@@ -32,6 +32,26 @@ RSpec.describe CirroIOV2::Resources::GigTimeActivity do
       expect(gig_time_activity.duration_in_ms).to eq(params[:duration_in_ms])
       expect(gig_time_activity.date).to eq(params[:date])
     end
+
+    context 'when testing response' do
+      let(:fixture_body) { JSON.parse(File.read('./spec/fixtures/gig_time_activity/create.json')) }
+      let(:request_url) { "#{site}/v2/gig_time_activities" }
+      let(:request_action) { :post }
+      let(:keys) { fixture_body.keys }
+      let(:replace_keys) do
+        {
+          'date' => 'delivery_date'
+        }
+      end
+      let(:expected_response_class) { CirroIOV2::Responses::GigTimeActivityResponse }
+      let(:expected_response) do
+        fixture_body.excluding(*replace_keys.values)
+      end
+
+      subject { described_class.new(client).create(params) }
+
+      include_examples 'responses'
+    end
   end
 
   describe '#list' do

--- a/spec/cirro_io_v2/resources/notification_broadcast_spec.rb
+++ b/spec/cirro_io_v2/resources/notification_broadcast_spec.rb
@@ -35,21 +35,21 @@ RSpec.describe CirroIOV2::Resources::NotificationBroadcast do
     end
 
     context 'when testing response' do
+      subject { described_class.new(client).create(params) }
+
       let(:fixture_body) { JSON.parse(File.read('./spec/fixtures/notification_broadcast/create.json')) }
       let(:request_url) { "#{site}/v2/notification_broadcasts" }
       let(:request_action) { :post }
       let(:keys) { fixture_body.keys }
       let(:replace_keys) do
         {
-          'payload' => 'content'
+          'payload' => 'content',
         }
       end
       let(:expected_response_class) { CirroIOV2::Responses::NotificationBroadcastResponse }
       let(:expected_response) do
         fixture_body.excluding(*replace_keys.values)
       end
-
-      subject { described_class.new(client).create(params) }
 
       include_examples 'responses'
     end

--- a/spec/cirro_io_v2/resources/notification_broadcast_spec.rb
+++ b/spec/cirro_io_v2/resources/notification_broadcast_spec.rb
@@ -33,5 +33,25 @@ RSpec.describe CirroIOV2::Resources::NotificationBroadcast do
         expect(created_notification_broadcast.notification_topic_id).to eq('1')
       end
     end
+
+    context 'when testing response' do
+      let(:fixture_body) { JSON.parse(File.read('./spec/fixtures/notification_broadcast/create.json')) }
+      let(:request_url) { "#{site}/v2/notification_broadcasts" }
+      let(:request_action) { :post }
+      let(:keys) { fixture_body.keys }
+      let(:replace_keys) do
+        {
+          'payload' => 'content'
+        }
+      end
+      let(:expected_response_class) { CirroIOV2::Responses::NotificationBroadcastResponse }
+      let(:expected_response) do
+        fixture_body.excluding(*replace_keys.values)
+      end
+
+      subject { described_class.new(client).create(params) }
+
+      include_examples 'responses'
+    end
   end
 end

--- a/spec/cirro_io_v2/resources/notification_layout_spec.rb
+++ b/spec/cirro_io_v2/resources/notification_layout_spec.rb
@@ -60,21 +60,21 @@ RSpec.describe CirroIOV2::Resources::NotificationLayout do
     end
 
     context 'when testing response' do
+      subject { described_class.new(client).create(params) }
+
       let(:fixture_body) { JSON.parse(File.read('./spec/fixtures/notification_layout/create.json')) }
       let(:request_url) { "#{site}/v2/notification_layouts" }
       let(:request_action) { :post }
       let(:keys) { fixture_body.keys }
       let(:replace_keys) do
         {
-          'templates' => 'content'
+          'templates' => 'content',
         }
       end
       let(:expected_response_class) { CirroIOV2::Responses::NotificationLayoutResponse }
       let(:expected_response) do
         fixture_body.excluding(*replace_keys.values)
       end
-
-      subject { described_class.new(client).create(params) }
 
       include_examples 'responses'
     end

--- a/spec/cirro_io_v2/resources/notification_layout_spec.rb
+++ b/spec/cirro_io_v2/resources/notification_layout_spec.rb
@@ -58,6 +58,26 @@ RSpec.describe CirroIOV2::Resources::NotificationLayout do
       expect(notification_layout.templates.data.first.notification_configuration_id).to eq(params[:templates].first[:notification_configuration_id])
       expect(notification_layout.templates.data.first.body).to eq(params[:templates].first[:body])
     end
+
+    context 'when testing response' do
+      let(:fixture_body) { JSON.parse(File.read('./spec/fixtures/notification_layout/create.json')) }
+      let(:request_url) { "#{site}/v2/notification_layouts" }
+      let(:request_action) { :post }
+      let(:keys) { fixture_body.keys }
+      let(:replace_keys) do
+        {
+          'templates' => 'content'
+        }
+      end
+      let(:expected_response_class) { CirroIOV2::Responses::NotificationLayoutResponse }
+      let(:expected_response) do
+        fixture_body.excluding(*replace_keys.values)
+      end
+
+      subject { described_class.new(client).create(params) }
+
+      include_examples 'responses'
+    end
   end
 
   describe '#update' do

--- a/spec/cirro_io_v2/resources/notification_layout_template_spec.rb
+++ b/spec/cirro_io_v2/resources/notification_layout_template_spec.rb
@@ -27,6 +27,26 @@ RSpec.describe CirroIOV2::Resources::NotificationLayoutTemplate do
       expect(notification_layout_template.notification_layout_id).to eq('1')
       expect(notification_layout_template.body).to eq(params[:body])
     end
+
+    context 'when testing response' do
+      let(:fixture_body) { JSON.parse(File.read('./spec/fixtures/notification_layout_template/update.json')) }
+      let(:request_url) { "#{site}/v2/notification_layout_templates/#{id}" }
+      let(:request_action) { :post }
+      let(:keys) { fixture_body.keys }
+      let(:replace_keys) do
+        {
+          'body' => 'content'
+        }
+      end
+      let(:expected_response_class) { CirroIOV2::Responses::NotificationLayoutTemplateResponse }
+      let(:expected_response) do
+        fixture_body.excluding(*replace_keys.values)
+      end
+
+      subject { described_class.new(client).update(id, params) }
+
+      include_examples 'responses'
+    end
   end
 
   describe '#delete' do

--- a/spec/cirro_io_v2/resources/notification_layout_template_spec.rb
+++ b/spec/cirro_io_v2/resources/notification_layout_template_spec.rb
@@ -29,21 +29,21 @@ RSpec.describe CirroIOV2::Resources::NotificationLayoutTemplate do
     end
 
     context 'when testing response' do
+      subject { described_class.new(client).update(id, params) }
+
       let(:fixture_body) { JSON.parse(File.read('./spec/fixtures/notification_layout_template/update.json')) }
       let(:request_url) { "#{site}/v2/notification_layout_templates/#{id}" }
       let(:request_action) { :post }
       let(:keys) { fixture_body.keys }
       let(:replace_keys) do
         {
-          'body' => 'content'
+          'body' => 'content',
         }
       end
       let(:expected_response_class) { CirroIOV2::Responses::NotificationLayoutTemplateResponse }
       let(:expected_response) do
         fixture_body.excluding(*replace_keys.values)
       end
-
-      subject { described_class.new(client).update(id, params) }
 
       include_examples 'responses'
     end

--- a/spec/cirro_io_v2/resources/notification_locale_spec.rb
+++ b/spec/cirro_io_v2/resources/notification_locale_spec.rb
@@ -24,21 +24,21 @@ RSpec.describe CirroIOV2::Resources::NotificationLocale do
     end
 
     context 'when testing response' do
+      subject { described_class.new(client).create(locale: locale) }
+
       let(:fixture_body) { JSON.parse(File.read('./spec/fixtures/notification_locale/create.json')) }
       let(:request_url) { "#{site}/v2/notification_locales" }
       let(:request_action) { :post }
       let(:keys) { fixture_body.keys }
       let(:replace_keys) do
         {
-          'configurations' => 'notification_configs'
+          'configurations' => 'notification_configs',
         }
       end
       let(:expected_response_class) { CirroIOV2::Responses::NotificationLocaleResponse }
       let(:expected_response) do
         fixture_body.excluding(*replace_keys.values)
       end
-
-      subject { described_class.new(client).create(locale: locale) }
 
       include_examples 'responses'
     end

--- a/spec/cirro_io_v2/resources/notification_locale_spec.rb
+++ b/spec/cirro_io_v2/resources/notification_locale_spec.rb
@@ -22,6 +22,26 @@ RSpec.describe CirroIOV2::Resources::NotificationLocale do
         expect(created_notification_locale.configurations.class).to eq(CirroIOV2::Responses::NotificationConfigurationListResponse)
       end
     end
+
+    context 'when testing response' do
+      let(:fixture_body) { JSON.parse(File.read('./spec/fixtures/notification_locale/create.json')) }
+      let(:request_url) { "#{site}/v2/notification_locales" }
+      let(:request_action) { :post }
+      let(:keys) { fixture_body.keys }
+      let(:replace_keys) do
+        {
+          'configurations' => 'notification_configs'
+        }
+      end
+      let(:expected_response_class) { CirroIOV2::Responses::NotificationLocaleResponse }
+      let(:expected_response) do
+        fixture_body.excluding(*replace_keys.values)
+      end
+
+      subject { described_class.new(client).create(locale: locale) }
+
+      include_examples 'responses'
+    end
   end
 
   describe '#list' do

--- a/spec/cirro_io_v2/resources/notification_template_spec.rb
+++ b/spec/cirro_io_v2/resources/notification_template_spec.rb
@@ -48,6 +48,26 @@ RSpec.describe CirroIOV2::Resources::NotificationTemplate do
       expect(updated_notification_template.subject).to eq(params[:subject])
       expect(updated_notification_template.body).to eq(params[:body])
     end
+
+    context 'when testing response' do
+      let(:fixture_body) { JSON.parse(File.read('./spec/fixtures/notification_template/create.json')) }
+      let(:request_url) { "#{site}/v2/notification_templates" }
+      let(:request_action) { :post }
+      let(:keys) { fixture_body.keys }
+      let(:replace_keys) do
+        {
+          'body' => 'content'
+        }
+      end
+      let(:expected_response_class) { CirroIOV2::Responses::NotificationTemplateResponse }
+      let(:expected_response) do
+        fixture_body.excluding(*replace_keys.values)
+      end
+
+      subject { described_class.new(client).create(params) }
+
+      include_examples 'responses'
+    end
   end
 
   describe '#update' do

--- a/spec/cirro_io_v2/resources/notification_template_spec.rb
+++ b/spec/cirro_io_v2/resources/notification_template_spec.rb
@@ -50,21 +50,21 @@ RSpec.describe CirroIOV2::Resources::NotificationTemplate do
     end
 
     context 'when testing response' do
+      subject { described_class.new(client).create(params) }
+
       let(:fixture_body) { JSON.parse(File.read('./spec/fixtures/notification_template/create.json')) }
       let(:request_url) { "#{site}/v2/notification_templates" }
       let(:request_action) { :post }
       let(:keys) { fixture_body.keys }
       let(:replace_keys) do
         {
-          'body' => 'content'
+          'body' => 'content',
         }
       end
       let(:expected_response_class) { CirroIOV2::Responses::NotificationTemplateResponse }
       let(:expected_response) do
         fixture_body.excluding(*replace_keys.values)
       end
-
-      subject { described_class.new(client).create(params) }
 
       include_examples 'responses'
     end

--- a/spec/cirro_io_v2/resources/notification_topic_spec.rb
+++ b/spec/cirro_io_v2/resources/notification_topic_spec.rb
@@ -39,6 +39,8 @@ RSpec.describe CirroIOV2::Resources::NotificationTopic do
     end
 
     context 'when testing response' do
+      subject { described_class.new(client).find(id) }
+
       let(:fixture_body) { JSON.parse(File.read('./spec/fixtures/notification_topic/find.json')) }
       let(:request_url) { "#{site}/v2/notification_topics/#{id}" }
       let(:request_action) { :get }
@@ -46,15 +48,13 @@ RSpec.describe CirroIOV2::Resources::NotificationTopic do
       let(:replace_keys) do
         {
           'name' => 'title',
-          'templates' => 'something'
+          'templates' => 'something',
         }
       end
       let(:expected_response_class) { CirroIOV2::Responses::NotificationTopicResponse }
       let(:expected_response) do
         fixture_body.excluding(*replace_keys.values)
       end
-
-      subject { described_class.new(client).find(id) }
 
       include_examples 'responses'
     end

--- a/spec/cirro_io_v2/resources/notification_topic_spec.rb
+++ b/spec/cirro_io_v2/resources/notification_topic_spec.rb
@@ -37,6 +37,27 @@ RSpec.describe CirroIOV2::Resources::NotificationTopic do
       expect(notification_topic.templates.class).to eq(CirroIOV2::Responses::NotificationTemplateListResponse)
       expect(notification_topic.templates.data.first.class).to eq(CirroIOV2::Responses::NotificationTemplateResponse)
     end
+
+    context 'when testing response' do
+      let(:fixture_body) { JSON.parse(File.read('./spec/fixtures/notification_topic/find.json')) }
+      let(:request_url) { "#{site}/v2/notification_topics/#{id}" }
+      let(:request_action) { :get }
+      let(:keys) { fixture_body.keys }
+      let(:replace_keys) do
+        {
+          'name' => 'title',
+          'templates' => 'something'
+        }
+      end
+      let(:expected_response_class) { CirroIOV2::Responses::NotificationTopicResponse }
+      let(:expected_response) do
+        fixture_body.excluding(*replace_keys.values)
+      end
+
+      subject { described_class.new(client).find(id) }
+
+      include_examples 'responses'
+    end
   end
 
   describe '#update' do

--- a/spec/cirro_io_v2/resources/payout_spec.rb
+++ b/spec/cirro_io_v2/resources/payout_spec.rb
@@ -35,6 +35,27 @@ RSpec.describe CirroIOV2::Resources::Payout do
       expect(payout.cost_center_key).to eq(params[:cost_center_key])
       expect(payout.cost_center_data).to be_nil
     end
+
+    context 'when testing response' do
+      let(:fixture_body) { JSON.parse(File.read('./spec/fixtures/payout/create.json')) }
+      let(:request_url) { "#{site}/v2/payouts" }
+      let(:request_action) { :post }
+      let(:keys) { fixture_body.keys }
+      let(:replace_keys) do
+        {
+          'title' => 'name',
+          'billing_date' => 'delivery_date'
+        }
+      end
+      let(:expected_response_class) { CirroIOV2::Responses::PayoutResponse }
+      let(:expected_response) do
+        fixture_body.excluding(*replace_keys.values)
+      end
+
+      subject { described_class.new(client).create(params) }
+
+      include_examples 'responses'
+    end
   end
 
   describe '#list' do

--- a/spec/cirro_io_v2/resources/payout_spec.rb
+++ b/spec/cirro_io_v2/resources/payout_spec.rb
@@ -37,6 +37,8 @@ RSpec.describe CirroIOV2::Resources::Payout do
     end
 
     context 'when testing response' do
+      subject { described_class.new(client).create(params) }
+
       let(:fixture_body) { JSON.parse(File.read('./spec/fixtures/payout/create.json')) }
       let(:request_url) { "#{site}/v2/payouts" }
       let(:request_action) { :post }
@@ -44,15 +46,13 @@ RSpec.describe CirroIOV2::Resources::Payout do
       let(:replace_keys) do
         {
           'title' => 'name',
-          'billing_date' => 'delivery_date'
+          'billing_date' => 'delivery_date',
         }
       end
       let(:expected_response_class) { CirroIOV2::Responses::PayoutResponse }
       let(:expected_response) do
         fixture_body.excluding(*replace_keys.values)
       end
-
-      subject { described_class.new(client).create(params) }
 
       include_examples 'responses'
     end

--- a/spec/cirro_io_v2/resources/shared/response_examples.rb
+++ b/spec/cirro_io_v2/resources/shared/response_examples.rb
@@ -1,7 +1,7 @@
 RSpec.shared_examples_for 'responses' do
   context 'when API endpoint changes attribute order or name' do
     it 'does not mess with the response attributes' do
-      fixture_body.transform_keys! { |key| replace_keys[key] ? replace_keys[key] : key }
+      fixture_body.transform_keys! { |key| replace_keys[key] || key }
       stub_request(request_action, request_url).to_return(body: fixture_body.to_json)
 
       expect(subject.class).to eq(expected_response_class)

--- a/spec/cirro_io_v2/resources/shared/response_examples.rb
+++ b/spec/cirro_io_v2/resources/shared/response_examples.rb
@@ -1,0 +1,21 @@
+RSpec.shared_examples_for 'responses' do
+  context 'when API endpoint changes attribute order or name' do
+    it 'does not mess with the response attributes' do
+      fixture_body.transform_keys! { |key| replace_keys[key] ? replace_keys[key] : key }
+      stub_request(request_action, request_url).to_return(body: fixture_body.to_json)
+
+      expect(subject.class).to eq(expected_response_class)
+      replace_keys.each do |key, _|
+        expect(subject.send(key)).to be_nil
+      end
+
+      expected_response.each do |key, value|
+        if value.is_a?(Hash)
+          expect(subject.send(key)).to eq(value.deep_symbolize_keys)
+        else
+          expect(subject.send(key)).to eq(value)
+        end
+      end
+    end
+  end
+end

--- a/spec/cirro_io_v2/resources/space_invitation_spec.rb
+++ b/spec/cirro_io_v2/resources/space_invitation_spec.rb
@@ -36,6 +36,27 @@ RSpec.describe CirroIOV2::Resources::SpaceInvitation do
       expect(space_invitation.skip_background_check).to eq(params[:skip_background_check])
       expect(space_invitation.expires_at).to eq('2023-05-12T00:00:00Z')
     end
+
+    context 'when testing response' do
+      let(:fixture_body) { JSON.parse(File.read('./spec/fixtures/space_invitation/create.json')) }
+      let(:request_url) { "#{site}/v2/space_invitations" }
+      let(:request_action) { :post }
+      let(:keys) { fixture_body.keys }
+      let(:replace_keys) do
+        {
+          'expires_at' => 'expires_in',
+          'subject' => 'object'
+        }
+      end
+      let(:expected_response_class) { CirroIOV2::Responses::SpaceInvitationResponse }
+      let(:expected_response) do
+        fixture_body.excluding(*replace_keys.values)
+      end
+
+      subject { described_class.new(client).create(params) }
+
+      include_examples 'responses'
+    end
   end
 
   describe '#expire' do

--- a/spec/cirro_io_v2/resources/space_invitation_spec.rb
+++ b/spec/cirro_io_v2/resources/space_invitation_spec.rb
@@ -38,6 +38,8 @@ RSpec.describe CirroIOV2::Resources::SpaceInvitation do
     end
 
     context 'when testing response' do
+      subject { described_class.new(client).create(params) }
+
       let(:fixture_body) { JSON.parse(File.read('./spec/fixtures/space_invitation/create.json')) }
       let(:request_url) { "#{site}/v2/space_invitations" }
       let(:request_action) { :post }
@@ -45,15 +47,13 @@ RSpec.describe CirroIOV2::Resources::SpaceInvitation do
       let(:replace_keys) do
         {
           'expires_at' => 'expires_in',
-          'subject' => 'object'
+          'subject' => 'object',
         }
       end
       let(:expected_response_class) { CirroIOV2::Responses::SpaceInvitationResponse }
       let(:expected_response) do
         fixture_body.excluding(*replace_keys.values)
       end
-
-      subject { described_class.new(client).create(params) }
 
       include_examples 'responses'
     end

--- a/spec/cirro_io_v2/resources/user_spec.rb
+++ b/spec/cirro_io_v2/resources/user_spec.rb
@@ -87,6 +87,35 @@ RSpec.describe CirroIOV2::Resources::User do
       expect(user.epam).to be_nil
       expect(user.worker[:billable]).to eq(false)
     end
+
+    context 'when testing response' do
+      let(:fixture_body) { JSON.parse(File.read('./spec/fixtures/user/find.json')) }
+      let(:request_url) { "#{site}/v2/users/#{user_id}" }
+      let(:request_action) { :get }
+      let(:keys) { fixture_body.keys }
+      let(:replace_keys) do
+        {
+          'anonymous_email' => 'email',
+          'first_name' => 'firstname',
+          'worker' => 'something_else'
+        }
+      end
+      let(:expected_response_class) { CirroIOV2::Responses::UserResponse }
+      let(:expected_response) do
+        {
+          id: user_id,
+          object: 'user',
+          last_name: fixture_body['last_name'],
+          time_zone: fixture_body['time_zone'],
+          birthday: fixture_body['birthday'],
+          country_code: fixture_body['country_code'],
+        }
+      end
+
+      subject { described_class.new(client).find(user_id) }
+
+      include_examples 'responses'
+    end
   end
 
   describe '#notification_preferences' do
@@ -145,6 +174,30 @@ RSpec.describe CirroIOV2::Resources::User do
       expect(notification_preference.locale).to eq('de')
       expect(notification_preference.topics.class).to eq(CirroIOV2::Responses::NotificationTopicPreferenceListResponse)
       expect(notification_preference.topics.data.first.class).to eq(CirroIOV2::Responses::NotificationTopicPreferenceResponse)
+    end
+
+    context 'when testing response' do
+      let(:fixture_body) { JSON.parse(File.read('./spec/fixtures/user/notification_preferences.json')) }
+      let(:request_url) { "#{site}/v2/users/#{user_id}/notification_preference" }
+      let(:request_action) { :get }
+      let(:keys) { fixture_body.keys }
+      let(:replace_keys) do
+        {
+          'topics' => 'channel'
+        }
+      end
+      let(:expected_response_class) { CirroIOV2::Responses::UserNotificationPreferenceResponse }
+      let(:expected_response) do
+        {
+          id: '1',
+          object: 'notification_preference',
+          locale: fixture_body['locale']
+        }
+      end
+
+      subject { described_class.new(client).notification_preference(user_id) }
+
+      include_examples 'responses'
     end
   end
 end

--- a/spec/cirro_io_v2/resources/user_spec.rb
+++ b/spec/cirro_io_v2/resources/user_spec.rb
@@ -89,6 +89,8 @@ RSpec.describe CirroIOV2::Resources::User do
     end
 
     context 'when testing response' do
+      subject { described_class.new(client).find(user_id) }
+
       let(:fixture_body) { JSON.parse(File.read('./spec/fixtures/user/find.json')) }
       let(:request_url) { "#{site}/v2/users/#{user_id}" }
       let(:request_action) { :get }
@@ -97,7 +99,7 @@ RSpec.describe CirroIOV2::Resources::User do
         {
           'anonymous_email' => 'email',
           'first_name' => 'firstname',
-          'worker' => 'something_else'
+          'worker' => 'something_else',
         }
       end
       let(:expected_response_class) { CirroIOV2::Responses::UserResponse }
@@ -111,8 +113,6 @@ RSpec.describe CirroIOV2::Resources::User do
           country_code: fixture_body['country_code'],
         }
       end
-
-      subject { described_class.new(client).find(user_id) }
 
       include_examples 'responses'
     end
@@ -177,13 +177,15 @@ RSpec.describe CirroIOV2::Resources::User do
     end
 
     context 'when testing response' do
+      subject { described_class.new(client).notification_preference(user_id) }
+
       let(:fixture_body) { JSON.parse(File.read('./spec/fixtures/user/notification_preferences.json')) }
       let(:request_url) { "#{site}/v2/users/#{user_id}/notification_preference" }
       let(:request_action) { :get }
       let(:keys) { fixture_body.keys }
       let(:replace_keys) do
         {
-          'topics' => 'channel'
+          'topics' => 'channel',
         }
       end
       let(:expected_response_class) { CirroIOV2::Responses::UserNotificationPreferenceResponse }
@@ -191,11 +193,9 @@ RSpec.describe CirroIOV2::Resources::User do
         {
           id: '1',
           object: 'notification_preference',
-          locale: fixture_body['locale']
+          locale: fixture_body['locale'],
         }
       end
-
-      subject { described_class.new(client).notification_preference(user_id) }
 
       include_examples 'responses'
     end

--- a/spec/fixtures/notification_topic/list.json
+++ b/spec/fixtures/notification_topic/list.json
@@ -11,13 +11,19 @@
       "preferences": {
         "email": "immediately"
       },
-      "templates": [
-        {
-          "notification_configuration_id": "1",
-          "subject": "New Bug Comment",
-          "body": "Hello {{recipient_first_name}}, you got {{#pluralize count, 'new comments'}}new comment{{/pluralize}}"
-        }
-      ]
+      "templates": {
+        "object": "list",
+        "data": [
+          {
+            "id": "1",
+            "object": "notification_template",
+            "notification_configuration_id": "1",
+            "notification_topic_id": "1",
+            "subject": "New Bug Comment",
+            "body": "Hello {{recipient_first_name}}, you got {{#pluralize count, 'new comments'}}new comment{{/pluralize}}"
+          }
+        ]
+      }
     }
   ]
 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ require 'faker'
 require 'cirro_io/client'
 require 'cirro_io_v2/client'
 Dir['spec/**/factories/**/*.rb'].each { |f| require f.partition('/').last }
-Dir['./spec/cirro_io_v2/resources/shared/*.rb'].each { |f| require f }
+Dir['./spec/cirro_io_v2/resources/shared/*.rb'].sort.each { |f| require f }
 
 # comment out below line and change values below to run test against actual API server
 require 'webmock/rspec'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'faker'
 require 'cirro_io/client'
 require 'cirro_io_v2/client'
 Dir['spec/**/factories/**/*.rb'].each { |f| require f.partition('/').last }
+Dir['./spec/cirro_io_v2/resources/shared/*.rb'].each { |f| require f }
 
 # comment out below line and change values below to run test against actual API server
 require 'webmock/rspec'


### PR DESCRIPTION
if we change order of API endpoint's response attributes or add or remove attribute inbetween, the response object has messed up attribute mapping.
