### PR TITLE
Deep_symbolize_keys when array in responce

### DIFF
--- a/lib/cirro_io_v2/responses/responses.rb
+++ b/lib/cirro_io_v2/responses/responses.rb
@@ -142,8 +142,7 @@ module CirroIOV2
       include Base
     end
 
-    NotificationTopicResponse = Struct.new(:id, :object, :name, :notification_layout_id, :preferences, :templates, keyword_init: true) do
-      self::NESTED_RESPONSES = { templates: :NotificationTemplateListResponse }.freeze
+    NotificationTopicResponse = Struct.new(:id, :object, :name, :notification_layout_id, :preferences, keyword_init: true) do
       include Base
     end
 


### PR DESCRIPTION
When `NotificationTopic.list` is called, we get templates wrapped in an array in response

`lib/cirro_io_v2/responses/base.rb` returns an error

Below is a step-by-step processing of the response:

1.
<img width="956" alt="Screenshot 2023-07-14 at 18 12 40" src="https://github.com/test-IO/cirro-ruby-client/assets/107075679/cb530b4b-ee9d-43a5-8a87-54ef0d63133d">
2. 
<img width="1329" alt="Screenshot 2023-07-14 at 18 12 56" src="https://github.com/test-IO/cirro-ruby-client/assets/107075679/803b5558-0a07-40e6-845f-d15b666f9e47">
3.
<img width="1326" alt="Screenshot 2023-07-14 at 18 13 28" src="https://github.com/test-IO/cirro-ruby-client/assets/107075679/c305f4b7-9efd-4c8e-990f-fade34fab7a9">
4.

`CirroIOV2::Responses::NotificationTemplateListResponse.constantize.new(body[:templates])`

<img width="1175" alt="Screenshot 2023-07-14 at 18 32 38" src="https://github.com/test-IO/cirro-ruby-client/assets/107075679/630d420a-0323-4a99-a884-5d427fb4ffcb">






