### PR TITLE
verbal 4xx reponses

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cirro-ruby-client (2.6.0)
+    cirro-ruby-client (2.6.1)
       activesupport
       faraday (< 1.2.0)
       faraday_middleware

--- a/lib/cirro_io/client/version.rb
+++ b/lib/cirro_io/client/version.rb
@@ -1,7 +1,7 @@
 # rubocop:disable Style/MutableConstant
 module CirroIO
   module Client
-    VERSION = '2.6.0'
+    VERSION = '2.6.1'
   end
 end
 # rubocop:enable Style/MutableConstant

--- a/lib/cirro_io_v2/client.rb
+++ b/lib/cirro_io_v2/client.rb
@@ -1,6 +1,7 @@
 require 'cirro_io/client/version'
 require 'cirro_io_v2/errors/http_error'
 require 'cirro_io_v2/errors/response_not_json_error'
+require 'cirro_io_v2/errors/client_error'
 
 require 'cirro_io_v2/request_clients/base'
 require 'cirro_io_v2/request_clients/jwt'

--- a/lib/cirro_io_v2/errors/client_error.rb
+++ b/lib/cirro_io_v2/errors/client_error.rb
@@ -1,0 +1,29 @@
+require 'forwardable'
+
+module CirroIOV2
+  module Errors
+    class ClientError < StandardError
+      extend Forwardable
+
+      def_instance_delegators :@faraday_error, :response, :full_message
+
+      attr_reader :faraday_error
+
+      # this error class is intended to be used ONLY for 4xx errors
+      # https://www.rubydoc.info/github/lostisland/faraday/Faraday/ClientError
+
+      def initialize(faraday_error)
+        @faraday_error = faraday_error
+      end
+
+      def message
+        puts faraday_error.response.inspect
+        faraday_error.response.then do |response|
+          return response.inspect if ENV.fetch('DEBUG_CIRRO_RUBY_CLIENT', false)
+
+          faraday_error.response[:body].presence || faraday_error.try[:message]
+        end
+      end
+    end
+  end
+end

--- a/lib/cirro_io_v2/request_clients/base.rb
+++ b/lib/cirro_io_v2/request_clients/base.rb
@@ -11,6 +11,8 @@ module CirroIOV2
         response
       rescue Faraday::ParsingError => e
         raise Errors::ResponseNotJsonError, e
+      rescue Faraday::ClientError => e
+        raise Errors::ClientError, e
       end
 
       def make_request(*args)


### PR DESCRIPTION
This PR is a cry for self-explanatory errors without the need to handle the Faraday exception.
probably need to check how other spaces handle Faraday::ClientError stuff

in a nutshell:
without the change 
<img width="1019" alt="Screenshot 2023-08-25 at 11 51 02" src="https://github.com/test-IO/cirro-ruby-client/assets/16397590/87330ec0-be06-40da-b173-3a5464e8a58a">

with the change but without the flag:
<img width="1508" alt="Screenshot 2023-08-25 at 10 44 50" src="https://github.com/test-IO/cirro-ruby-client/assets/16397590/deafe93f-afc4-4dac-9fa6-44e2be28a3c8">

with the change with the flag:
<img width="1509" alt="Screenshot 2023-08-25 at 10 44 41" src="https://github.com/test-IO/cirro-ruby-client/assets/16397590/01185b91-514d-49fd-87e3-221f8b6d4bda">

