### PR TITLE
Revert "[EPMCIR-2702] Update NotificationTopicPreference + in_app"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cirro-ruby-client (2.6.5)
+    cirro-ruby-client (2.6.6)
       activesupport
       faraday (< 1.2.0)
       faraday_middleware

--- a/lib/cirro_io/client/version.rb
+++ b/lib/cirro_io/client/version.rb
@@ -1,7 +1,7 @@
 # rubocop:disable Style/MutableConstant
 module CirroIO
   module Client
-    VERSION = '2.6.5'
+    VERSION = '2.6.6'
   end
 end
 # rubocop:enable Style/MutableConstant

--- a/lib/cirro_io_v2/resources/notification_topic_preference.rb
+++ b/lib/cirro_io_v2/resources/notification_topic_preference.rb
@@ -9,16 +9,6 @@ module CirroIOV2
         response = client.request_client.request(:get, resource_root, params:)
         Responses::NotificationTopicPreferenceListResponse.new(response.body)
       end
-
-      def create(params)
-        response = client.request_client.request(:post, resource_root, body: params)
-        Responses::NotificationTopicPreferenceResponse.new(response.body)
-      end
-
-      def update(id, params)
-        response = client.request_client.request(:post, "#{resource_root}/#{id}", body: params)
-        Responses::NotificationTopicPreferenceResponse.new(response.body)
-      end
     end
   end
 end

--- a/spec/cirro_io_v2/resources/notification_topic_preference_spec.rb
+++ b/spec/cirro_io_v2/resources/notification_topic_preference_spec.rb
@@ -18,62 +18,6 @@ RSpec.describe CirroIOV2::Resources::NotificationTopicPreference do
       expect(notification_topic_preferences.object).to eq('list')
       expect(notification_topic_preferences.url).to eq('/notification_topic_preferences')
       expect(notification_topic_preferences.data.first.class).to eq(CirroIOV2::Responses::NotificationTopicPreferenceResponse)
-      expect(notification_topic_preferences.data.first.user_id).to eq('1')
-      expect(notification_topic_preferences.data.first.notification_topic_id).to eq('1')
-      expect(notification_topic_preferences.data.first.preferences).to eq(email: 'immediately')
-    end
-  end
-
-  describe '#create' do
-    let(:params) do
-      {
-        app_user_id: '1',
-        notification_topic_id: '1',
-        preferences: {
-          email: 'never',
-        },
-      }
-    end
-
-    it 'creates a notification topic preference' do
-      stub_api = stub_request(:post, "#{site}/v2/notification_topic_preferences")
-                 .to_return(body: File.read('./spec/fixtures/notification_topic_preference/create.json'))
-
-      notification_topic_preference = described_class.new(client).create(params)
-
-      expect(stub_api).to have_been_made
-      expect(notification_topic_preference.class).to eq(CirroIOV2::Responses::NotificationTopicPreferenceResponse)
-      expect(notification_topic_preference.object).to eq('notification_topic_preference')
-      expect(notification_topic_preference.user_id).to eq('1')
-      expect(notification_topic_preference.notification_topic_id).to eq('1')
-      expect(notification_topic_preference.preferences[:email]).to eq('never')
-    end
-  end
-
-  describe '#update' do
-    let(:id) { '1' }
-    let(:params) do
-      {
-        app_user_id: '1',
-        notification_topic_id: '1',
-        preferences: {
-          email: 'never',
-        },
-      }
-    end
-
-    it 'updates a notification topic preference' do
-      stub_api = stub_request(:post, "#{site}/v2/notification_topic_preferences/#{id}")
-                 .to_return(body: File.read('./spec/fixtures/notification_topic_preference/update.json'))
-
-      notification_topic_preference = described_class.new(client).update(id, params)
-
-      expect(stub_api).to have_been_made
-      expect(notification_topic_preference.class).to eq(CirroIOV2::Responses::NotificationTopicPreferenceResponse)
-      expect(notification_topic_preference.object).to eq('notification_topic_preference')
-      expect(notification_topic_preference.user_id).to eq('1')
-      expect(notification_topic_preference.notification_topic_id).to eq('1')
-      expect(notification_topic_preference.preferences[:email]).to eq('never')
     end
   end
 end

--- a/spec/fixtures/notification_topic_preference/create.json
+++ b/spec/fixtures/notification_topic_preference/create.json
@@ -1,9 +1,0 @@
-{
-    "id": "1",
-    "object": "notification_topic_preference",
-    "notification_topic_id": "1",
-    "user_id": "1",
-    "preferences": {
-        "email": "never"
-    }
-}

--- a/spec/fixtures/notification_topic_preference/update.json
+++ b/spec/fixtures/notification_topic_preference/update.json
@@ -1,9 +1,0 @@
-{
-    "id": "1",
-    "object": "notification_topic_preference",
-    "notification_topic_id": "1",
-    "user_id": "1",
-    "preferences": {
-        "email": "never"
-    }
-}


### PR DESCRIPTION
This reverts commit 64141505
Additional endpoint to update or create `notification topic preference` is not necessary.

It is appeared that we can use ready made endpoint to update and create `notification topic preference`:
https://api-docs.cirro.io/docs/users/notification_preferences/create_update
```
client = CirroIOV2::Client.new(...)
params = {
  "locale": "de",
  "topics": [
    {
      "id": "1",
      "preferences": {
        "email": "immediately"
      }
    }
  ]
}
client.User.notification_preferences(1, params)
```