### PR TITLE
[No Ticket] Add user.delete endpoint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cirro-ruby-client (2.7.2)
+    cirro-ruby-client (2.7.3)
       activesupport
       faraday (< 1.11.0)
       faraday_middleware

--- a/lib/cirro_io/client/version.rb
+++ b/lib/cirro_io/client/version.rb
@@ -1,7 +1,7 @@
 # rubocop:disable Style/MutableConstant
 module CirroIO
   module Client
-    VERSION = '2.7.2'
+    VERSION = '2.7.3'
   end
 end
 # rubocop:enable Style/MutableConstant

--- a/lib/cirro_io_v2/resources/user.rb
+++ b/lib/cirro_io_v2/resources/user.rb
@@ -11,6 +11,11 @@ module CirroIOV2
         CirroIOV2::Responses::UserResponse.new(response.body)
       end
 
+      def delete(id)
+        response = client.request_client.request(:delete, "#{resource_root}/#{id}")
+        Responses::UserDeleteResponse.new(response.body)
+      end
+
       def notification_preference(id)
         response = client.request_client.request(:get, "#{resource_root}/#{id}/notification_preference")
         CirroIOV2::Responses::UserNotificationPreferenceResponse.new(response.body)

--- a/lib/cirro_io_v2/responses/responses.rb
+++ b/lib/cirro_io_v2/responses/responses.rb
@@ -16,6 +16,7 @@ module CirroIOV2
     ].freeze
 
     DELETE_RESPONSES = [
+      :UserDeleteResponse,
       :GigDeleteResponse,
       :PayoutDeleteResponse,
       :NotificationTemplateDeleteResponse,

--- a/spec/cirro_io_v2/resources/user_spec.rb
+++ b/spec/cirro_io_v2/resources/user_spec.rb
@@ -125,6 +125,23 @@ RSpec.describe CirroIOV2::Resources::User do
     end
   end
 
+  describe '#delete' do
+    let(:id) { '1' }
+
+    it 'deletes a user' do
+      stub_api = stub_request(:delete, "#{site}/v2/users/#{id}")
+                 .to_return(body: File.read('./spec/fixtures/user/delete.json'), headers: { 'Content-Type' => 'application/json' })
+
+      deleted_user = described_class.new(client).delete(id)
+
+      expect(stub_api).to have_been_made
+      expect(deleted_user.class).to eq(CirroIOV2::Responses::UserDeleteResponse)
+      expect(deleted_user.id).to eq(id)
+      expect(deleted_user.object).to eq('user')
+      expect(deleted_user.deleted).to eq(nil)
+    end
+  end
+
   describe '#notification_preferences' do
     it 'creates notification_preferences' do
       stub_api = stub_request(:post, "#{site}/v2/users/#{user_id}/notification_preferences")

--- a/spec/fixtures/user/delete.json
+++ b/spec/fixtures/user/delete.json
@@ -1,0 +1,5 @@
+{
+  "id": "1",
+  "object": "user",
+  "deleted": null
+}


### PR DESCRIPTION
We added a new endpoint -- users.delete -- to Cirro and need to update the client.