### PR TITLE
[Without-ticket] Fix error encoding issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cirro-ruby-client (2.8.0)
+    cirro-ruby-client (2.8.1)
       activesupport
       faraday (~> 2.0)
       json_api_client (>= 1.10.0)

--- a/lib/cirro_io/client/version.rb
+++ b/lib/cirro_io/client/version.rb
@@ -1,7 +1,7 @@
 # rubocop:disable Style/MutableConstant
 module CirroIO
   module Client
-    VERSION = '2.8.0'
+    VERSION = '2.8.1'
   end
 end
 # rubocop:enable Style/MutableConstant

--- a/lib/cirro_io_v2/errors/client_error.rb
+++ b/lib/cirro_io_v2/errors/client_error.rb
@@ -17,12 +17,11 @@ module CirroIOV2
       end
 
       def message
-        puts faraday_error.response.inspect
-        faraday_error.response.then do |response|
-          return response.inspect if ENV.fetch('DEBUG_CIRRO_RUBY_CLIENT', false)
+        return faraday_error.response.inspect if ENV['DEBUG_CIRRO_RUBY_CLIENT']
 
-          faraday_error.response[:body].presence || faraday_error.try(:message)
-        end
+        body = faraday_error.response&.dig(:body)
+        result = body.presence || faraday_error.try(:message)
+        result.is_a?(String) ? result : result.to_json
       end
     end
   end

--- a/spec/cirro_io_v2/client_spec.rb
+++ b/spec/cirro_io_v2/client_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe CirroIOV2::Client do
       it 'raises CirroIOV2::Errors::ClientError when request fails with 4xx' do
         expect { client.request_client.request(:foo, :bar) }.to raise_error(CirroIOV2::Errors::ClientError) do |error|
           expect(error.faraday_error.message).to eq('test')
-          expect(error.message).to eq({ error: 'error' })
+          expect(error.message).to eq('{"error":"error"}')
         end
       end
     end

--- a/spec/cirro_io_v2/errors/client_error_spec.rb
+++ b/spec/cirro_io_v2/errors/client_error_spec.rb
@@ -1,0 +1,97 @@
+RSpec.describe CirroIOV2::Errors::ClientError do
+  subject(:error) { described_class.new(faraday_error) }
+
+  let(:exception) { RuntimeError.new('something went wrong') }
+  let(:response) { { status: 422, body: body } }
+  let(:faraday_error) { Faraday::ClientError.new(exception, response) }
+
+  describe '#message' do
+    context 'when response body is a String' do
+      let(:body) { '<html><body>Internal Server Error</body></html>' }
+
+      it 'returns the string body as-is' do
+        expect(error.message).to eq('<html><body>Internal Server Error</body></html>')
+      end
+    end
+
+    context 'when response body is a Hash (parsed JSON)' do
+      let(:body) { { 'error' => 'Validation failed', 'details' => ['Name is required'] } }
+
+      it 'returns a JSON string, not a Hash' do
+        expect(error.message).to be_a(String)
+      end
+
+      it 'serializes the hash to JSON' do
+        expect(error.message).to eq('{"error":"Validation failed","details":["Name is required"]}')
+      end
+    end
+
+    context 'when response body is nil' do
+      let(:body) { nil }
+
+      it 'falls back to the faraday_error message' do
+        expect(error.message).to eq('something went wrong')
+      end
+    end
+
+    context 'when response body is an empty string' do
+      let(:body) { '' }
+
+      it 'falls back to the faraday_error message' do
+        expect(error.message).to eq('something went wrong')
+      end
+    end
+
+    context 'when response itself is nil' do
+      let(:faraday_error) { Faraday::ClientError.new(exception, nil) }
+
+      it 'does not raise an error' do
+        expect { error.message }.not_to raise_error
+      end
+
+      it 'falls back to the faraday_error message' do
+        expect(error.message).to eq('something went wrong')
+      end
+    end
+
+    context 'when DEBUG_CIRRO_RUBY_CLIENT env var is set' do
+      before do
+        stub_const('ENV', ENV.to_h.merge('DEBUG_CIRRO_RUBY_CLIENT' => 'true'))
+      end
+
+      let(:body) { { 'error' => 'Validation failed' } }
+
+      it 'returns the full response inspect string' do
+        expect(error.message).to eq(faraday_error.response.inspect)
+      end
+
+      it 'returns a String' do
+        expect(error.message).to be_a(String)
+      end
+    end
+
+    context 'when message is used with .encode (downstream requirement)' do
+      let(:body) { { 'error' => 'Validation failed' } }
+
+      it 'can be encoded to UTF-8 when body is a Hash' do
+        expect { error.message.encode('UTF-8') }.not_to raise_error
+      end
+    end
+
+    context 'when message is used with .encode for a String body' do
+      let(:body) { 'Bad Request' }
+
+      it 'can be encoded to UTF-8 when body is a String' do
+        expect { error.message.encode('UTF-8') }.not_to raise_error
+      end
+    end
+
+    context 'when message is used with .encode for a nil body' do
+      let(:body) { nil }
+
+      it 'can be encoded to UTF-8 when falling back to faraday message' do
+        expect { error.message.encode('UTF-8') }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/cirro_io_v2/errors/client_error_spec.rb
+++ b/spec/cirro_io_v2/errors/client_error_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe CirroIOV2::Errors::ClientError do
   subject(:error) { described_class.new(faraday_error) }
 
   let(:exception) { RuntimeError.new('something went wrong') }
-  let(:response) { { status: 422, body: body } }
+  let(:response) { { status: 422, body: } }
   let(:faraday_error) { Faraday::ClientError.new(exception, response) }
 
   describe '#message' do


### PR DESCRIPTION
## Fix `NoMethodError: undefined method 'encode' for an instance of Hash` in `ClientError#message`

### Context

Sidekiq has a number of retries reported a `NoMethodError` in `CirroIOJobs::UpdateGig` with **no backtrace**:

```
Job:    CirroIOJobs::UpdateGig
Args:   [1040002]
Error:  NoMethodError — undefined method `encode' for an instance of Hash
```

No backtrace made this look like a mystery bug in the job itself. After investigation, it turned out to be a bug in how `ClientError` reports error messages — **masking the real API error underneath**.

### Root Cause

When the Cirro API returns a JSON error response (e.g. 422), Faraday's middleware stack processes it in this order:

```mermaid
sequenceDiagram
    participant Job as UpdateGig Job
    participant Client as CirroIOV2::Client
    participant Faraday as Faraday Stack
    participant API as Cirro API

    Job->>Client: Gig.update(id, params)
    Client->>Faraday: POST /api/v2/gigs/:id
    Faraday->>API: HTTP Request
    API-->>Faraday: 422 JSON Response {"error": "..."}

    Note over Faraday: :json middleware parses body<br/>String → Hash
    Note over Faraday: :raise_error middleware<br/>raises Faraday::ClientError<br/>with body as Hash

    Faraday-->>Client: Faraday::ClientError (body = Hash)
    Client-->>Job: CirroIOV2::Errors::ClientError

    Note over Job: Sidekiq/Airbrake calls<br/>error.message.encode('UTF-8')

    Note over Job: 💥 message returns Hash<br/>Hash has no .encode method<br/>→ NoMethodError
```

The problem is in `ClientError#message`:

```ruby
# before
def message
  puts faraday_error.response.inspect  # debug leak to stdout
  faraday_error.response.then do |response|
    return response.inspect if ENV.fetch('DEBUG_CIRRO_RUBY_CLIENT', false)
    faraday_error.response[:body].presence || faraday_error.try(:message)
    #                      ^^^^^^
    #  This is a Hash (parsed by Faraday's JSON middleware)
    #  .presence returns the Hash as-is
    #  → message returns a Hash, not a String
  end
end
```

When Sidekiq or Airbrake calls `.encode('UTF-8')` on the error message (standard for string encoding), it fails because `Hash` has no `.encode` method.

**This is a masking bug** — the real Cirro API error (likely a validation failure) is never visible in Sidekiq because the secondary `NoMethodError` replaces it.